### PR TITLE
Add study-level metadata support

### DIFF
--- a/src/main/java/org/nrg/xnat/dicomweb/rest/WadoRsApi.java
+++ b/src/main/java/org/nrg/xnat/dicomweb/rest/WadoRsApi.java
@@ -261,6 +261,44 @@ public class WadoRsApi extends AbstractXapiRestController {
     }
 
     /**
+     * Retrieve study-level metadata
+     * GET /dicomweb/projects/{projectId}/studies/{studyUID}/metadata
+     */
+    @XapiRequestMapping(
+            value = "/dicomweb/projects/{projectId}/studies/{studyUID}/metadata",
+            method = RequestMethod.GET,
+            produces = "application/dicom+json"
+    )
+    @ApiOperation(value = "Retrieve study-level metadata (WADO-RS)", response = String.class)
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Study metadata retrieved"),
+            @ApiResponse(code = 401, message = "Must be authenticated"),
+            @ApiResponse(code = 404, message = "Study not found"),
+            @ApiResponse(code = 500, message = "Internal error")
+    })
+    public ResponseEntity<String> retrieveStudyMetadata(@PathVariable String projectId,
+                                                        @PathVariable String studyUID) {
+        try {
+            UserI user = getSessionUser();
+            Attributes attrs = dicomService.retrieveStudyMetadata(user, projectId, studyUID);
+
+            if (attrs == null) {
+                return ResponseEntity.notFound().build();
+            }
+
+            String json = "[" + DicomWebUtils.toJson(attrs) + "]";
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(DicomWebUtils.getDicomJsonContentType()))
+                    .body(json);
+
+        } catch (Exception e) {
+            logger.error("Error retrieving study metadata for study: " + studyUID, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
      * Retrieve metadata for all instances in a series
      * GET /dicomweb/projects/{projectId}/studies/{studyUID}/series/{seriesUID}/metadata
      */

--- a/src/main/java/org/nrg/xnat/dicomweb/service/XnatDicomService.java
+++ b/src/main/java/org/nrg/xnat/dicomweb/service/XnatDicomService.java
@@ -38,6 +38,11 @@ public interface XnatDicomService {
     Attributes retrieveMetadata(UserI user, String projectId, String studyInstanceUID, String seriesInstanceUID, String sopInstanceUID);
 
     /**
+     * Retrieve study-level metadata
+     */
+    Attributes retrieveStudyMetadata(UserI user, String projectId, String studyInstanceUID);
+
+    /**
      * Retrieve all instances in a study
      */
     List<InputStream> retrieveStudy(UserI user, String projectId, String studyInstanceUID);


### PR DESCRIPTION
## Summary

- Add new REST endpoint for study-level metadata: `GET /dicomweb/projects/{projectId}/studies/{studyUID}/metadata`
- Add `retrieveStudyMetadata` method to service interface and implementation
- Enhance study attributes with comprehensive metadata including:
  - Study timing (StudyDate, StudyTime)
  - Series and instance counts (NumberOfStudyRelatedSeries, NumberOfStudyRelatedInstances)
  - Institution name
  - Modalities in study
  - Patient identification

## Test plan

- [x] Build passes with all tests
- [ ] Manual testing with XNAT instance
- [ ] Verify metadata endpoint returns correct DICOM JSON format
- [ ] Verify series/instance counts are accurate